### PR TITLE
Fix DNS parsing bugs and infinite loop in protocol.rs

### DIFF
--- a/src/dns/protocol.rs
+++ b/src/dns/protocol.rs
@@ -125,8 +125,10 @@ pub fn parse_response(data: &[u8], record_type: RecordType) -> Result<Vec<String
         return Err("DNS error response");
     }
 
+    // Get question count
+    let qdcount = u16::from_be_bytes([data[4], data[5]]);
     // Get answer count
-    let ancount = u16::from_be_bytes([data[4], data[5]]);
+    let ancount = u16::from_be_bytes([data[6], data[7]]);
     if ancount == 0 {
         return Err("no answers in response");
     }
@@ -134,18 +136,14 @@ pub fn parse_response(data: &[u8], record_type: RecordType) -> Result<Vec<String
     // Skip header (12 bytes) and question section
     let mut pos = 12;
 
-    // Skip question section (find the null terminator, then skip QTYPE and QCLASS)
-    while pos < data.len() && data[pos] != 0 {
-        let label_len = data[pos] as usize;
-        pos += 1 + label_len;
-        if pos > data.len() {
-            return Err("malformed question section");
+    // Skip question sections
+    for _ in 0..qdcount {
+        pos = skip_name(data, pos)?;
+        if pos + 4 > data.len() {
+            return Err("truncated question section");
         }
+        pos += 4; // Skip QTYPE (2) + QCLASS (2)
     }
-    if pos >= data.len() {
-        return Err("truncated question section");
-    }
-    pos += 1 + 4; // Skip null terminator + QTYPE (2) + QCLASS (2)
 
     let mut results = Vec::new();
 
@@ -196,6 +194,8 @@ pub fn parse_response(data: &[u8], record_type: RecordType) -> Result<Vec<String
                                 txt.push_str(s);
                             }
                             txt_pos += len;
+                        } else {
+                            break;
                         }
                     }
                     if !txt.is_empty() {


### PR DESCRIPTION
Fixed multiple bugs in the DNS response parsing logic in `src/dns/protocol.rs` that affected correctness and could lead to infinite loops.

Specifically:
- Extracted `qdcount` and `ancount` from the correct header offsets.
- Replaced a naive loop that skipped exactly one question section (and could crash/loop on compression pointers) with a loop that skips exactly `qdcount` questions using the existing `skip_name` function.
- Added a `break` condition when parsing TXT records to prevent an infinite loop when the specified text length exceeds the bounds of the packet.

---
*PR created automatically by Jules for task [5144257441194288536](https://jules.google.com/task/5144257441194288536) started by @zer0horizon*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes

* Enhanced DNS response parsing with improved validation and boundary checking.
* Better handling of question sections to prevent truncation-related failures.
* Strengthened text record parsing logic to prevent boundary overruns.
* Improved error detection for malformed or incomplete DNS protocol data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->